### PR TITLE
Fix pageDelta fallback in PUIController

### DIFF
--- a/src/API/PUIController.ts
+++ b/src/API/PUIController.ts
@@ -365,7 +365,8 @@ export default class PUIController {
 
     $page_items.each((index: number, page) => {
       const p = $(page);
-      const pageDelta = parseInt(p.attr("number") || "index", 10);
+      const pageNumberAttr = p.attr("number");
+      const pageDelta = pageNumberAttr != null ? parseInt(pageNumberAttr, 10) : index;
       const pageInfo = { section, owner, book, page: startPage + pageDelta };
 
       const surface_pu = {


### PR DESCRIPTION
## Summary
- ensure page index defaults to loop index without unnecessary parsing when `number` attribute is missing in `readPageSymbols`

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6880d927ea7c832188200c8b1a2052b8